### PR TITLE
Add download tag

### DIFF
--- a/tasks/Oracle.yml
+++ b/tasks/Oracle.yml
@@ -15,12 +15,15 @@
 # Any implementation of Java (Oracle and OpenJDK) need some Ansible
 #   specific configuration.
 - include: common.yml
-  tags: java
-
+  tags:
+    - java
+    - download
 
 # Test whether we need to download Java.
 - name: Verify Oracle Java redis package sha256sum (local)
-  tags: java
+  tags:
+    - java
+    - download
   ignore_errors: true
   local_action: command
     shasum
@@ -38,7 +41,9 @@
 # context of a local network instead of downloading Java again
 # for every role/node which depends on this role.
 - name: Download Oracle Java redis package (local)
-  tags: java
+  tags:
+    - java
+    - download
   local_action: command
     curl
       --location
@@ -48,12 +53,15 @@
       --cookie-jar /tmp/{{ java_oracle_redis_filename }}.cookie
       {{ java_oracle_redis_mirror }}
     chdir={{ ansible_data_path }}
+    creates={{ ansible_data_path }}/{{ java_oracle_redis_filename }}
   register: java_oracle_redis_download
   when: java_oracle_redis_exists.rc != 0
 
 # Test whether downloaded redistributable package passes sha256sum
 - name: Verify Oracle Java redis package sha256sum (local)
-  tags: java
+  tags:
+    - java
+    - download
   local_action: command
     shasum
       --algorithm 256

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -3,7 +3,9 @@
 
 # this directory will contain the Java downloads
 - name: Install Java download directory (local)
-  tags: java
+  tags:
+    - java
+    - download
   local_action: file
     state=directory
     owner=0
@@ -14,7 +16,9 @@
 
 # Test whether we need to download Java.
 - name: Install Oracle Java redis package sha256sum (local)
-  tags: java
+  tags:
+    - java
+    - download
   local_action: template
     src=sha256sum.j2
     dest={{ ansible_data_path }}/java.sha256sum

--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -4,7 +4,9 @@
 #  tags: java
 
 - name: Fail on invalid user data
-  tags: java
+  tags:
+    - java
+    - download
   fail:
     msg="java_default_implementation must be one of 'oracle' or 'openjdk'"
   when: java_default_implementation not in ['oracle', 'openjdk']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,9 @@
 #
 #   Fail the play if it runs on an unsupported platform,
 - name: Assert platform is supported
-  tags: java
+  tags:
+    - java
+    - download
   assert:
     that:
       - ansible_os_family in ['Debian', 'RedHat']
@@ -12,12 +14,10 @@
 
 # Install OpenJDK only if specifically activated.
 - include: OpenJDK.yml
-  tags: java
   when: java_openjdk_when
 
 # Install Oracle JDK only if specifically activated.
 - include: Oracle.yml
-  tags: java
   when: java_oracle_when
 
 # Configure the systems default Java implementation if any 


### PR DESCRIPTION
Add a download tag. It can be used to download the JDK files in an open environment (ansible-playbook --tags="download"), then copy the files to a secured box with no internet connection and run the installation without internet (ansible-playbook --skip-tags="download")
