### PR TITLE
Added changes which will allow to run the role from non-privileged user

### DIFF
--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -16,12 +16,8 @@
 #   downloading Java.
 - name: Install local ansible data path directory
   tags: java
-  sudo: yes
   local_action: file
     state=directory
-    owner=0
-    group=0
-    mode=2777
     dest={{ local_ansible_data_path }}
 
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# path for ansible to store downloaded or templated data
+# path for ansible to store downloaded or templated data, ansible control machine should be able to write into parent folder (local_action!)
 local_ansible_data_path: /usr/local/src/ansible/data
 remote_ansible_data_path: "{{ local_ansible_data_path }}"
 


### PR DESCRIPTION
Hi Mark,
Great role, will use it!

It was critical to me that ansible control machine worked from generic user, since sudo is not always available.
Didn't see how to disable sudo during runtime deliberately for local_action without preventing role to work with sudo on target server...
