### PR TITLE
Java 6 and 32bit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Install Oracle Java.
 
 ## Compatibility
 
-### ansible-java 0.7.0
+### ansible-java 0.9.0
 
 Starting with this role version, inventory configuration for pinned
 versions of Java to be installed has changed.
@@ -52,6 +52,8 @@ the *vars/versions* directory. When configuring a version, that is not predefine
 * ``java_oracle_mirror_jce``: Mirror URL for the download of the Oracle Java JCE policies package
 * ``java_oracle_redis_jce_filename``:  File name of the Oracle Java JCE policies package
 * ``java_oracle_redis_jce_archive_dirname``: Name of the base directory in the Oracle Java JCE policies package
+* ``java_oracle_redis_platform``: Platform of Java JDK/JRE redistributable package - ``x64`` (default) and ``i586`` are supported
+* ``java_oracle_redis_extension``: Extension of Java JDK/JRE redistributable package - ``tar.gz`` (default) and ``bin`` (for Java 6) are supported
 
 ### Supported versions
 
@@ -59,6 +61,8 @@ the *vars/versions* directory. When configuring a version, that is not predefine
 * 7u71
 * 8u20
 * 8u25
+* 6u24
+* 6u24_32bit
 
 ## Role facts
 
@@ -97,6 +101,6 @@ Marc Rohlfs @marc.rohlfs silpion.de
 * Sebastian Davids @sebastian.davids silpion.de
 * [ludovicc](https://github.com/ludovicc)
 * [nixlike](https://github.com/nixlike)
-
+* [bberto](https://github.com/bberto)
 
 <!-- vim: set ts=4 sw=4 et nofen: -->

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -35,9 +35,7 @@
   failed_when: false
   register: java_oracle_redis_exists
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java.sha256sum
@@ -50,9 +48,7 @@
   failed_when: false
   register: java_oracle_redis_jce_exists
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java_jce.sha256sum
@@ -134,9 +130,7 @@
   sudo_user: "{{ util_local_action_sudo_user|default(omit) }}"
   when: java_oracle_redis_download|changed
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java.sha256sum
@@ -147,9 +141,7 @@
   sudo_user: "{{ util_local_action_sudo_user|default(omit) }}"
   when: java_oracle_redis_jce_download|changed
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java_jce.sha256sum

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,15 +72,24 @@
     dest={{ util_persistent_data_path_remote }}/{{ item }}
     owner=0
     group=0
-    mode=0644
+    mode=0744
 
 - name: Install Java
   tags: java
   sudo: yes
+  when: java_oracle_version_minor > 6
   unarchive:
     src={{ util_persistent_data_path_remote }}/{{ java_oracle_redis_filename }}
     dest={{ java_install_dir }}/oracle/
     copy=false
+    creates={{ java_install_dir }}/oracle/{{ java_oracle_version_str_pkg }}
+
+- name: Install Java 6
+  tags: java
+  sudo: yes
+  when: java_oracle_version_minor <= 6
+  shell: /{{ util_persistent_data_path_remote }}/{{ java_oracle_redis_filename }} < /bin/echo A
+    chdir={{ java_install_dir }}/oracle/
     creates={{ java_install_dir }}/oracle/{{ java_oracle_version_str_pkg }}
 
 - name: Unarchive Java JCE package

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,4 @@
 ---
 java_package_list:
   - unzip
+  - ia32-libs

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,4 @@
 ---
 java_package_list:
   - unzip
+  - glibc.i686

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,15 +9,18 @@ java_oracle_mirror: "{{ java_oracle_mirror_base }}/jdk"
 #   configure a version string Oracle uses from their version information
 java_oracle_version_str_redis: "{{ java_oracle_version_minor }}u{{ java_oracle_version_update }}"
 
+java_oracle_redis_extension: "tar.gz"
+java_oracle_redis_platform: "x64"
+
 #   Redistributable package names
-java_oracle_redis_jdk_filename: "jdk-{{ java_oracle_version_str_redis }}-linux-x64.tar.gz"
-java_oracle_redis_jre_filename: "jre-{{ java_oracle_version_str_redis }}-linux-x64.tar.gz"
+java_oracle_redis_jdk_filename: "jdk-{{ java_oracle_version_str_redis }}-linux-{{ java_oracle_redis_platform }}.{{ java_oracle_redis_extension }}"
+java_oracle_redis_jre_filename: "jre-{{ java_oracle_version_str_redis }}-linux-{{ java_oracle_redis_platform }}.{{ java_oracle_redis_extension }}"
 
 #   top level directory within the Oracle redis archive
 java_oracle_version_str_pkg: "{{ java_oracle_distribution }}{{ java_oracle_version_major }}.{{ java_oracle_version_minor }}.{{ java_oracle_version_patch }}_{{ java_oracle_version_update }}"
 
 #   source file name for either the JRE or JDK for the Oracle Java implementation
-java_oracle_redis_filename: "{{ java_oracle_distribution }}-{{ java_oracle_version_str_redis }}-linux-x64.tar.gz"
+java_oracle_redis_filename: "{{ java_oracle_distribution }}-{{ java_oracle_version_str_redis }}-linux-{{ java_oracle_redis_platform }}.{{ java_oracle_redis_extension }}"
 
 #   complete URL for downloading either the JRE or JDK for the Oracle Java implementation
 java_oracle_redis_mirror: "{{ java_oracle_mirror }}/{{ java_oracle_version_minor }}u{{ java_oracle_version_update }}-b{{ java_oracle_version_build }}/{{ java_oracle_redis_filename }}"

--- a/vars/versions/6u24.yml
+++ b/vars/versions/6u24.yml
@@ -1,0 +1,17 @@
+---
+java_oracle_version_major: 1
+java_oracle_version_minor: 6
+java_oracle_version_patch: 0
+java_oracle_version_update: 24
+java_oracle_version_build: "07"
+
+java_oracle_redis_extension: "bin"
+
+java_oracle_redis_jdk_sha256sum: b3ab9771eb2e163814d876dd3e7dcd71be9088209f40d68237eb9b0553407cdd
+java_oracle_redis_jre_sha256sum: b5125924200ed0035eb5547d6b7e5c4bcf4772a58e4a78835e54d76255924de8
+java_oracle_redis_jce_sha256sum: d0c2258c3364120b4dbf7dd1655c967eee7057ac6ae6334b5ea8ceb8bafb9262
+java_oracle_mirror_jce: "{{ java_oracle_mirror_base }}/jce_policy/6"
+java_oracle_redis_jce_filename: jce_policy-6.zip
+java_oracle_redis_jce_archive_dirname: jce
+
+

--- a/vars/versions/6u24_32bit.yml
+++ b/vars/versions/6u24_32bit.yml
@@ -1,0 +1,19 @@
+---
+java_oracle_version_major: 1
+java_oracle_version_minor: 6
+java_oracle_version_patch: 0
+java_oracle_version_update: 24
+java_oracle_version_build: "07"
+
+java_oracle_redis_extension: "bin"
+
+java_oracle_redis_platform: "i586"
+
+java_oracle_redis_jdk_sha256sum: 7b3fa4d029277dc396e2bc88e2b578404a625f8427c921319968c58c6523d004
+java_oracle_redis_jre_sha256sum: 8ce84fd30b1d6beaffef3f24d8d5f6f1807fe62ec659a120ac7c2b59b2e9edfd
+java_oracle_redis_jce_sha256sum: d0c2258c3364120b4dbf7dd1655c967eee7057ac6ae6334b5ea8ceb8bafb9262
+java_oracle_mirror_jce: "{{ java_oracle_mirror_base }}/jce_policy/6"
+java_oracle_redis_jce_filename: jce_policy-6.zip
+java_oracle_redis_jce_archive_dirname: jce
+
+


### PR DESCRIPTION
Hello,

I worked on supporting Java 6u24 and 32bit installation. 

Tested on vagrant box chef/centos-6.5, that required switching shasum (seems unavailable on CentOS) to sha256sum.