### PR TITLE
Changed checksum commands from shasum to sha256 for REHL compatibility

### DIFF
--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -32,9 +32,7 @@
   changed_when: false
   register: java_oracle_redis_exists
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java.sha256sum
@@ -46,9 +44,7 @@
   changed_when: false
   register: java_oracle_redis_jce_exists
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java_jce.sha256sum
@@ -118,9 +114,7 @@
   tags: java
   when: java_oracle_redis_download|changed
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java.sha256sum
@@ -129,9 +123,7 @@
   tags: java
   when: java_oracle_redis_jce_download|changed
   local_action: command
-    shasum
-      --algorithm 256
-      --portable
+    sha256sum
       --check
       --status
       {{ util_persistent_data_path_local }}/java_jce.sha256sum


### PR DESCRIPTION
I made the changes from shasum to sha256sum for REHL. https://github.com/silpion/ansible-java/issues/12 Indicated sha256sum is supported on ubuntu, so the change from shasum to sha256sum shouldn't cause any issues for the ubuntu users.