### PR TITLE
Remove assumption about the roles path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
   tags:
     - java
     - java_download
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/version-specific-vars.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/version-specific-vars.yml"
   vars:
     version: "{{ java_oracle_version }}"
 
@@ -47,12 +47,12 @@
 
 - name: Include OS specific configuration
   tags: java
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/os-specific-vars.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/os-specific-vars.yml"
 
 
 - name: Include assets persistency tasks
   tags: java
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/datapersistency.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/datapersistency.yml"
 
 
 # Manage local download of Oracle Java redistributable
@@ -94,7 +94,7 @@
   with_items:
     - "{{ java_oracle_redis_filename }}"
     - "{{ java_oracle_redis_jce_filename }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/copy.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/copy.yml"
   vars:
     filename: "{{ item }}"
 
@@ -149,7 +149,7 @@
 
 - name: Include local facts tasks
   tags: java
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/localfacts.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/localfacts.yml"
   vars:
     namespace: java
 


### PR DESCRIPTION
This removes the assumption that roles for a playbook are installed in a
directory called `roles` beneath `playbook.yml` (which can make the including
of os-specific or version-specific variables fail).

Instead, this assumes that all roles are checked out in a same directory.
This will break implementations where roles that use silpion.lib are installed
in a separate directory, but this use case should be less common than having
oles installed somewhere else than a directory called `roles` beneath
`playbook.yml`.