### PR TITLE
Update to 8u131

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ java_oracle_distribution: "{{ ansible_local.java.general.distribution if (((ansi
 java_oracle_curl_cookie: accept-securebackup-cookie
 
 #   Version information
-java_oracle_version: "{{ ansible_local.java.general.version if (((ansible_local|default({})).java|default({})).general|default({})).version is defined else '8u112' }}"
+java_oracle_version: "{{ ansible_local.java.general.version if (((ansible_local|default({})).java|default({})).general|default({})).version is defined else '8u131' }}"
 
 # Base installation directory for any Java implementation/distribution
 java_install_dir: /opt/java

--- a/vars/versions/8u131.yml
+++ b/vars/versions/8u131.yml
@@ -1,0 +1,16 @@
+---
+java_oracle_version_major: 1
+java_oracle_version_minor: 8
+java_oracle_version_patch: 0
+java_oracle_version_update: 131
+java_oracle_version_build: 11
+
+java_oracle_redis_jdk_sha256sum: 62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236
+java_oracle_redis_jre_sha256sum: 355e5cdb066d4cada1f9f16f358b6fa6280ff5caf7470cf0d5cdd43083408d35
+java_oracle_redis_srv_sha256sum: a80634d17896fe26e432f6c2b589ef6485685b2e717c82cd36f8f747d40ec84b
+java_oracle_redis_jce_sha256sum: f3020a3922efd6626c2fff45695d527f34a8020e938a49292561f18ad1320b59
+java_oracle_mirror_jce: "{{ java_oracle_mirror_base }}/jce/8"
+java_oracle_redis_jce_filename: jce_policy-8.zip
+java_oracle_redis_jce_archive_dirname: UnlimitedJCEPolicyJDK8
+
+java_oracle_redis_mirror: "{{ java_oracle_mirror }}/{{ java_oracle_version }}-b{{ java_oracle_version_build }}/d54c1d3a095b4ff2b6607d096fa80163/{{ java_oracle_redis_filename }}"


### PR DESCRIPTION
Looks like Oracle now requires an OTN account to download older java versions since last week, so this role can only be used to download the latest installer.

It's still possible to use this role to install older versions of java by manually downloading the installer archive to ~/.ansible/assets/  or another local path by overriding the var {{ lib_persistent_data_path_local }}